### PR TITLE
Implementing Acl Sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 # Build ignores.
 .tox
 .coverage
+.cache
 build
 dist

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ To use the library, simply do the following:
 
 ### development
 #### test
+Testing against local you will want to export a couple environment variables:
+
+```sh
+export OR_DEFAULT_API_URL='http://localhost:5050/v2/'
+export OR_DEFAULT_ADMIN_API_URL='http://localhost:5050/admin/'
+```
+
 Before you push your code, run `tox` from the top level directory. If errors
 are reported, fix them.
 

--- a/objectrocket/__init__.py
+++ b/objectrocket/__init__.py
@@ -2,5 +2,5 @@
 # Import this object for ease of access.
 from objectrocket.client import Client  # noqa
 
-VERSION = ('0', '3', '0')
+VERSION = ('0', '3', '1')
 __version__ = '.'.join(VERSION)

--- a/objectrocket/__init__.py
+++ b/objectrocket/__init__.py
@@ -2,5 +2,5 @@
 # Import this object for ease of access.
 from objectrocket.client import Client  # noqa
 
-VERSION = ('0', '2', '0')
+VERSION = ('0', '3', '0')
 __version__ = '.'.join(VERSION)

--- a/objectrocket/auth.py
+++ b/objectrocket/auth.py
@@ -46,8 +46,15 @@ class Auth(bases.BaseAuthLayer):
 
         # Attempt to extract authentication data.
         try:
-            json_data = resp.json()
-            token = json_data['data']['token']
+            if resp.status_code == 200:
+                json_data = resp.json()
+                token = json_data['data']['token']
+            elif resp.status_code == 401:
+                raise errors.AuthFailure(resp.json().get('message', 'Authentication Failure.'))
+            else:
+                raise errors.AuthFailure("Unknown exception while authenticating: '{}'".format(resp.text))
+        except errors.AuthFailure:
+            raise
         except Exception as ex:
             logging.exception(ex)
             raise errors.AuthFailure('{}: {}'.format(ex.__class__.__name__, ex))

--- a/objectrocket/bases.py
+++ b/objectrocket/bases.py
@@ -103,8 +103,14 @@ class BaseInstance(object):
         self.__instances = instances
         self.__instance_document = instance_document
 
+        if 'connect_string' in instance_document:
+            self._connect_string = instance_document['connect_string']
+        elif 'connection_strings' in instance_document:
+            self._connect_string = instance_document['connection_strings']
+        else:
+            raise errors.InstancesException('No connection string found.')
+
         # Bind required pseudo private attributes from API response document.
-        self._connect_string = instance_document['connect_string']
         self._created = instance_document['created']
         self._name = instance_document['name']
         self._plan = instance_document['plan']

--- a/objectrocket/bases.py
+++ b/objectrocket/bases.py
@@ -1,6 +1,7 @@
 """Base classes used throughout the library."""
 import abc
-
+import json
+import requests
 import six
 
 from objectrocket import errors
@@ -119,6 +120,52 @@ class BaseInstance(object):
             .format(self.__class__.__name__, self._instance_document, _id)
         )
         return rep
+
+    def acl_sync(self, aws_sync=None, rackspace_sync=None):
+        """Adjust Amazon Web Services and/or Rackspace Acl Sync feature for this instance.
+
+        :param bool aws_sync: True/False whether to enable AWS acl sync for this instance.
+        :param bool rackspace_sync: True/False whether to enable Rackspace acl sync for this instance.
+        """
+        url = self._url + 'acl_sync'
+
+        data = {"aws_acl_sync_enabled": False, "rackspace_acl_sync_enabled": False}
+
+        # Let's get current status of acl sync for this intance to set proper defaults.
+        response = requests.get(url, **self._instances._default_request_kwargs)
+
+        if response.status_code == 200:
+            resp_json = response.json()
+            current_status = resp_json.get('data', {})
+            data.update({"aws_acl_sync_enabled": current_status.get("aws_acl_sync_enabled", False),
+                         "rackspace_acl_sync_enabled": current_status.get("rackspace_acl_sync_enabled", False)})
+            if aws_sync is not None:
+                data.update({"aws_acl_sync_enabled": aws_sync})
+            if rackspace_sync is not None:
+                data.update({"rackspace_acl_sync_enabled": rackspace_sync})
+
+            response = requests.put(url, data=json.dumps(data), **self._instances._default_request_kwargs)
+            return response.json()
+        else:
+            raise errors.ObjectRocketException("Couldn't get current status of instance, failing.  Error: {}".format(response.text))
+
+    def run_acl_sync(self, aws_sync=False, rackspace_sync=False):
+        """Run Acl sync for this instance.
+
+        :param bool aws_sync: True/False whether to run AWS acl sync for this instance immediately.
+        :param bool rackspace_sync: True/False whether to run Rackspace acl sync for this instance immediately.
+        """
+        url = self._url + 'acl_sync'
+
+        data = {"aws_acl_sync_enabled": False, "rackspace_acl_sync_enabled": False}
+
+        if aws_sync:
+            data.update({"aws_acl_sync_enabled": True})
+        if rackspace_sync:
+            data.update({"rackspace_acl_sync_enabled": True})
+
+        response = requests.post(url, data=json.dumps(data), **self._instances._default_request_kwargs)
+        return response.json()
 
     @property
     def connect_string(self):

--- a/objectrocket/instances/__init__.py
+++ b/objectrocket/instances/__init__.py
@@ -8,7 +8,7 @@ import requests
 from objectrocket import bases
 from objectrocket import util
 from objectrocket.instances.mongodb import MongodbInstance
-from objectrocket.instances.mongodb import TokumxInstance
+from objectrocket.instances.elasticsearch import ESInstance
 from objectrocket.instances.redis import RedisInstance
 
 logger = logging.getLogger(__name__)
@@ -38,12 +38,12 @@ class Instances(bases.BaseOperationsLayer):
         return self._concrete_instance_list(data)
 
     @util.token_auto_auth
-    def create(self, name, size, zone,
+    def create(self, name, plan, zone,
                service_type='mongodb', instance_type='mongodb_sharded', version='2.4.6'):
         """Create an ObjectRocket instance.
 
         :param str name: The name to give to the new instance.
-        :param int size: The size in gigabytes of the new instance.
+        :param int plan: The size in gigabytes of the new instance. ** Unless == 500 and then it's in mb.
         :param str zone: The zone that the new instance is to exist in.
         :param str service_type: The type of service that the new instance is to provide.
         :param str instance_type: The instance type to create.
@@ -54,7 +54,7 @@ class Instances(bases.BaseOperationsLayer):
         request_data = {
             'name': name,
             'service': service_type,
-            'size': size,
+            'plan': plan,
             'type': instance_type,
             'version': version,
             'zone': zone
@@ -158,8 +158,8 @@ class Instances(bases.BaseOperationsLayer):
         """A mapping of service names to service classes."""
         service_map = {
             'mongodb': MongodbInstance,
+            'elasticsearch': ESInstance,
             'redis': RedisInstance,
-            'tokumx': TokumxInstance,
         }
         return service_map
 

--- a/objectrocket/instances/elasticsearch.py
+++ b/objectrocket/instances/elasticsearch.py
@@ -1,0 +1,34 @@
+"""Elasticsearch instance class and logic."""
+import datetime
+import json
+import logging
+
+import requests
+
+from objectrocket import bases
+from objectrocket import util
+
+logger = logging.getLogger(__name__)
+
+
+class ESInstance(bases.BaseInstance, bases.Extensible):
+    """An ObjectRocket Elasticsearch service instance.
+
+    :param dict instance_document: A dictionary representing the instance object, most likey coming
+        from the ObjectRocket API.
+    :param objectrocket.instances.Instances instances: An instance of
+        :py:class:`objectrocket.instances.Instances`.
+    """
+
+    def __init__(self, instance_document, instances):
+        super(ESInstance, self).__init__(
+            instance_document=instance_document,
+            instances=instances
+        )
+
+    def get_connection(self, ssl=True):
+        """Get a live connection to this instance.
+
+        :param bool ssl: Use SSL/TLS if available for this instance.
+        """
+        return True

--- a/objectrocket/instances/mongodb.py
+++ b/objectrocket/instances/mongodb.py
@@ -152,19 +152,3 @@ class MongodbInstance(bases.BaseInstance, bases.Extensible):
             connect_string = self.ssl_connect_string
 
         return pymongo.MongoClient(connect_string)
-
-
-class TokumxInstance(MongodbInstance):
-    """An ObjectRocket TokuMX service instance.
-
-    :param dict instance_document: A dictionary representing the instance object, most likey coming
-        from the ObjectRocket API.
-    :param objectrocket.instances.Instances instances: An instance of
-        :py:class:`objectrocket.instances.Instances`.
-    """
-
-    def __init__(self, instance_document, instances):
-        super(TokumxInstance, self).__init__(
-            instance_document=instance_document,
-            instances=instances
-        )

--- a/objectrocket/instances/mongodb.py
+++ b/objectrocket/instances/mongodb.py
@@ -8,6 +8,7 @@ import requests
 
 from objectrocket import bases
 from objectrocket import util
+from objectrocket import errors
 
 logger = logging.getLogger(__name__)
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,4 @@ sphinx_rtd_theme
 tox>=2.0
 wheel>=0.22.0
 git+https://github.com/mverteuil/pytest-ipdb.git
+responses>=0.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@ pytest>=2.5.2
 pytest-cov>=1.7.0
 setuptools>=2.1
 sphinx_rtd_theme
-tox>=2.0
+tox>=2.1
 wheel>=0.22.0
 git+https://github.com/mverteuil/pytest-ipdb.git
 responses>=0.4.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,4 @@
+elasticsearch>=1.0.0,<2.0.0
 pymongo>=2.7
 redis>=2.0
 requests>=2.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from objectrocket.client import Client
 from objectrocket import instances
 from objectrocket import constants
 
-
 # def pytest_generate_tests(metafunc):
 #     """Generate tests for the different instance types."""
 #     if '_docs' in metafunc.fixturenames:
@@ -93,15 +92,15 @@ def mongodb_sharded_doc():
 
 
 @pytest.fixture
-def mongodb_replicaset_instance(client_token_auth, mongodb_replica_doc):
+def mongodb_replicaset_instance(client, mongodb_replica_doc):
     return instances.MongodbInstance(instance_document=mongodb_replica_doc,
-                                     client=client_token_auth)
+                                     instances=client.instances)
 
 
 @pytest.fixture
-def mongodb_sharded_instance(client_token_auth, mongodb_sharded_doc):
+def mongodb_sharded_instance(client, mongodb_sharded_doc):
     return instances.MongodbInstance(instance_document=mongodb_sharded_doc,
-                                     client=client_token_auth)
+                                     instances=client.instances)
 
 
 ######################
@@ -121,10 +120,6 @@ def patched_requests_map(request):
         which is patching the requests library in its respective module.
     """
     patches = {}
-
-    mocked = mock.patch('objectrocket.auth.requests', autospec=True)
-    request.addfinalizer(mocked.stop)
-    patches['auth'] = mocked.start()
 
     mocked = mock.patch('objectrocket.instances.requests', autospec=True)
     request.addfinalizer(mocked.stop)

--- a/tests/test_acl_sync.py
+++ b/tests/test_acl_sync.py
@@ -1,0 +1,127 @@
+import copy
+import json
+import mock
+import pytest
+import responses
+
+from objectrocket.bases import BaseInstance
+
+@pytest.yield_fixture(autouse=True)
+def ensure_production_url(mongodb_sharded_instance, instance_acl_url):
+    """Fixture that ensures that the proper production URLs are used in tests,
+    instead of the potentially overridden ones from environment variables.
+
+    See objectrocket.constants.OR_DEFAULT_API_URL
+    """
+    inst = mongodb_sharded_instance
+    with mock.patch.object(BaseInstance, '_url', new_callable=mock.PropertyMock) as mock_url:
+        type(mock_url).return_value = instance_acl_url.replace('acl_sync', '')
+        yield
+
+@pytest.fixture
+def instance_acl_url(mongodb_sharded_instance):
+    return "https://sjc-api.objectrocket.com/v2/instances/{}/acl_sync".format(mongodb_sharded_instance.name)
+
+class TestSetGetAclSync:
+
+    @responses.activate
+    def test_acl_sync_disables(self, client, mongodb_sharded_instance, instance_acl_url):
+        inst = mongodb_sharded_instance
+        responses.add(responses.PUT, instance_acl_url,
+                      status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_enabled': False,
+                                       'rackspace_acl_sync_enabled': False}}),
+                      content_type="application/json")
+        responses.add(responses.GET, instance_acl_url, status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_enabled': True,
+                                       'rackspace_acl_sync_enabled': True}}),
+                      content_type="application/json")
+
+        response = inst.acl_sync(aws_sync=False, rackspace_sync=False)
+
+        assert isinstance(response, dict) is True
+        assert response.get('data', {}).get('aws_acl_sync_enabled', True) is False
+        assert response.get('data', {}).get('rackspace_acl_sync_enabled', True) is False
+
+    @responses.activate
+    def test_acl_sync_enables(self, client, mongodb_sharded_instance, instance_acl_url):
+        inst = mongodb_sharded_instance
+        responses.add(responses.PUT, instance_acl_url,
+                      status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_enabled': True,
+                                       'rackspace_acl_sync_enabled': True}}),
+                      content_type="application/json")
+        responses.add(responses.GET, instance_acl_url, status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_enabled': False,
+                                       'rackspace_acl_sync_enabled': False}}),
+                      content_type="application/json")
+
+        response = inst.acl_sync(aws_sync=False, rackspace_sync=False)
+
+        assert isinstance(response, dict) is True
+        assert response.get('data', {}).get('aws_acl_sync_enabled', False) is True
+        assert response.get('data', {}).get('rackspace_acl_sync_enabled', False) is True
+
+    @responses.activate
+    def test_acl_sync_just_returns_status(self, client, mongodb_sharded_instance, instance_acl_url):
+        inst = mongodb_sharded_instance
+        responses.add(responses.GET, instance_acl_url, status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_enabled': True,
+                                       'rackspace_acl_sync_enabled': True}}),
+                      content_type="application/json")
+        responses.add(responses.PUT, instance_acl_url,
+                      status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_enabled': False,
+                                       'rackspace_acl_sync_enabled': False}}),
+                      content_type="application/json")
+
+        response = inst.acl_sync()
+
+        assert isinstance(response, dict) is True
+        assert response.get('data', {}).get('aws_acl_sync_enabled', True) is False
+        assert response.get('data', {}).get('rackspace_acl_sync_enabled', True) is False
+
+    @responses.activate
+    def test_acl_sync_raises(self, client, mongodb_sharded_instance, instance_acl_url):
+        inst = mongodb_sharded_instance
+        exception = Exception('Test Exception')
+        responses.add(responses.GET, instance_acl_url, status=500,
+                      body=exception)
+
+        with pytest.raises(Exception) as exinfo:
+            response = inst.acl_sync()
+
+        assert exinfo is not None
+        assert exinfo.value[0] == 'Test Exception'
+
+class TestRunAclSync:
+
+    @responses.activate
+    def test_run_sync_without_args_is_unchanged(self, client, mongodb_sharded_instance, instance_acl_url):
+        inst = mongodb_sharded_instance
+        responses.add(responses.POST, instance_acl_url,
+                      status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_state': 'unchanged',
+                                       'rackspace_acl_sync_state': 'unchanged'}}),
+                      content_type="application/json")
+
+        response = inst.run_acl_sync()
+
+        assert isinstance(response, dict) is True
+        assert response.get('data', {}).get('aws_acl_sync_state', None) == 'unchanged'
+        assert response.get('data', {}).get('rackspace_acl_sync_state', None) == 'unchanged'
+
+    @responses.activate
+    def test_run_sync_starts(self, client, mongodb_sharded_instance, instance_acl_url):
+        inst = mongodb_sharded_instance
+        responses.add(responses.POST, instance_acl_url,
+                      status=200,
+                      body=json.dumps({'data': {'aws_acl_sync_state': 'started',
+                                       'rackspace_acl_sync_state': 'started'}}),
+                      content_type="application/json")
+
+        response = inst.run_acl_sync(aws_sync=True, rackspace_sync=True)
+
+        assert isinstance(response, dict) is True
+        assert response.get('data', {}).get('aws_acl_sync_state', None) == 'started'
+        assert response.get('data', {}).get('rackspace_acl_sync_state', None) == 'started'

--- a/tests/test_bases.py
+++ b/tests/test_bases.py
@@ -6,7 +6,6 @@ from objectrocket.bases import BaseInstance
 from objectrocket.bases import BaseOperationsLayer
 
 REQUIRED_INSTANCE_FIELDS = [
-    'connect_string',
     'created',
     'name',
     'plan',
@@ -60,6 +59,15 @@ def test_instance_creation_fails_with_missing_field(client, mongodb_sharded_doc,
         InstancePrototype(instance_document=mongodb_sharded_doc, instances=client.instances)
 
     assert exinfo.value.args == (needed_field,)
+
+
+def test_instance_creation_fails_with_missing_connect_string(client, mongodb_sharded_doc):
+    mongodb_sharded_doc.pop("connect_string", None)
+
+    with pytest.raises(errors.InstancesException) as exinfo:
+        InstancePrototype(instance_document=mongodb_sharded_doc, instances=client.instances)
+
+    assert str(exinfo.value) == 'No connection string found.'
 
 
 def test_instance_repr_is_as_expected(client, mongodb_sharded_doc):


### PR DESCRIPTION
Implementing Setting/Getting/Running of Objectrocket Acl Sync on instances via ApiV2.
Fixing failing auth tests.
Using responses library for mocking/testing api requests.
Proper tests for get/set/run acl sync.
Completes #22