### PR TITLE
Release 0.4.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-VERSION = ('0', '4', '8')
+VERSION = ('0', '4', '9')
 __version__ = '.'.join(VERSION)
 
 with open('README.md') as f:

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ index-servers =
     pypitest
 
 [pypi]
-repository = https://pypi.python.org/pypi
+repository = https://upload.pypi.org/legacy/
 
 [pypitest]
 repository = https://testpypi.python.org/pypi


### PR DESCRIPTION
Adjusting pypi url per recommendation
https://packaging.python.org/guides/migrating-to-pypi-org/